### PR TITLE
Helokuを使ってデプロイ

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,1 @@
-release: php artisan migrate:fresh
 web: vendor/bin/heroku-php-apache2 public/

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+release: php artisan migrate:fresh
+web: vendor/bin/heroku-php-apache2 public/

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,6 +4,9 @@ namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
 
+//Schemaクラスをuseする
+use Illuminate\Support\Facades\Schema;
+
 class AppServiceProvider extends ServiceProvider
 {
     /**
@@ -24,5 +27,6 @@ class AppServiceProvider extends ServiceProvider
     public function boot()
     {
         //
+        Schema::defaultStringLength(191);
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Facades\Schema;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -21,7 +22,6 @@ class AppServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    use Illuminate\Support\Facades\Schema;
 
     public function boot()
     {

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,9 +4,6 @@ namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
 
-//Schemaクラスをuseする
-use Illuminate\Support\Facades\Schema;
-
 class AppServiceProvider extends ServiceProvider
 {
     /**
@@ -24,6 +21,8 @@ class AppServiceProvider extends ServiceProvider
      *
      * @return void
      */
+    use Illuminate\Support\Facades\Schema;
+
     public function boot()
     {
         //

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
         "watch-poll": "mix watch -- --watch-options-poll=1000",
         "hot": "mix watch --hot",
         "prod": "npm run production",
-        "production": "mix --production"
+        "production": "mix --production",
+        "heroku-postbuild": "npm run prod"
     },
     "devDependencies": {
         "@tailwindcss/forms": "^0.4.0",


### PR DESCRIPTION
## 概要

Herokuを使ってデプロイを行いました。
MySQLを使っているので、DBの設定をHerokuのアドオンclearDBを使って行っています。

- `app/Providers/AppServiceProvider.php`にvarchar型の文字数を191に制限する設定を追記
- `Procfile`というHerokuの設定ファイルを作成し、Herokuアプリの起動時に実行するプロセスを定義
https://devcenter.heroku.com/ja/articles/deploying-php#the-procfile


## 確認方法

1. `http://laravel-sample-task.herokuapp.com/`にアクセスする
2. ユーザー登録、ログインができるか確認する

## コメント

deployというブランチでデプロイするためのDBの設定をいくつか行ったのですが、
Herokuにpushする時に`git push heroku main`としていて、変更内容が反映されておらず、
データベースを作成するマイグレーションを実行するとSyntaxエラーが出てしまいました。
（このSyntaxエラーはMySQL5.7を使っている場合に出るもので、
varchar型の文字数を191に制限する必要があるようです。）
https://qiita.com/beer_geek/items/6e4264db142745ea666f
ここで今回行ったDBの設定が一切反映されてないのではということに気づきました。
なので下記のような手順でDB作成まで行いました。

mainブランチに移動して、`git pull origin deploy`、`git push heroku main`、
`heroku run php artisan migrate:fresh`を行うことでデプロイが完了しました。

gitのブランチに関して詰まってしまってすごく初歩的なミスだった。。。