### PR TITLE
新規登録後、ログイン後の遷移先をrootに変更

### DIFF
--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -17,7 +17,7 @@ class RouteServiceProvider extends ServiceProvider
      *
      * @var string
      */
-    public const HOME = '/dashboard';
+    public const HOME = '/';
 
     /**
      * The controller namespace for the application.


### PR DESCRIPTION
## 概要

ユーザー新規登録、ログイン後の画面遷移先がデフォルトだと`/dashboard`になっていました。
そうではなくて`/`に遷移するように設定しました。
`app/Providers/RouteServiceProvider.php`に定数HOMEが定義されていたので下記のように修正しました。
```PHP
public const HOME = '/';
```

## 確認方法

1. ユーザー登録後の遷移先が`/dashboard`ではなくて`/`になっていることを確認する
2. ログイン後の遷移先が`/dashboard`ではなくて`/`になっていることを確認する
3. ログイン前に`/dashboard`にアクセスすると/loginに遷移する

## コメント

デフォルトで`/dashoboard`に遷移していることに気が付きませんでした。
Railsでは基本的なユーザー登録後の遷移先はデフォルトで`/`にしていたなあということで`/`に修正しました。

[![Image from Gyazo](https://i.gyazo.com/4a4816b1d6fc5cb88de743289d32f227.gif)](https://gyazo.com/4a4816b1d6fc5cb88de743289d32f227)